### PR TITLE
Passed an optional url for initClient

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -61,8 +61,7 @@ describe('submitForm', () => {
     beforeAll(() => {
         initClient(
             app,
-            'testDatabaseName',
-            'testRegion'
+            'https://testDatabaseName.testRegion.firebasedatabase.app',
         );
     });
     it('should set form data and listen for status changes', async () => {
@@ -149,8 +148,7 @@ describe('submitForm with custom status map', () => {
         jest.clearAllMocks();
         initClient(
             app,
-            'testDatabaseName',
-            'testRegion',
+            'https://testDatabaseName.testRegion.firebasedatabase.app',
             {
                 "submit": "Submit",
                 "delay": "Delay",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,10 @@ let db: Database;
 let statusMap: Record<string, string> = {};
 export function initClient(
     app: FirebaseApp,
-    databaseName: string,
-    region: string,
+    url?: string,
     _statusMap?: Record<string, string>,
 ) {
-    db = getDatabase(app, `https://${databaseName}.${region}.firebasedatabase.app/`);
+    db = getDatabase(app, url);
     statusMap = _statusMap || {};
 }
 export async function submitForm(


### PR DESCRIPTION
Instead of passing databaseName and region, we just use an optional url: string in initClient. This allows users to pass proper url/localhost url based on their use case.