### PR TITLE
Pass @messages field in status callback handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emberflow-rn-client",
-  "version": "1.0.28",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emberflow-rn-client",
-      "version": "1.0.28",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.3",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -21,7 +21,7 @@ function runCallback() {
 const onReturnMock = jest.fn();
 const formRefMock = {
     key: 'testDocId',
-    set: jest.fn((formData) => {
+    set: jest.fn((formData: any) => {
         _formData = formData;
     }),
     push: jest.fn().mockReturnThis(),
@@ -31,6 +31,17 @@ const formRefMock = {
     }),
     off: jest.fn(),
     update: jest.fn(),
+    once: jest.fn((eventType: string, callback: Function) => {
+        const mockSnapshot = {
+            val: () => {
+                return {
+                    "@status": "validation-error",
+                    "@messages": {name: "Invalid"}
+                };
+            }
+        };
+        callback(mockSnapshot);
+    }),
 };
 
 const dbRefMock = jest.fn();
@@ -123,6 +134,40 @@ describe('submitForm', () => {
         await form.unsubscribe();
         expect(formRefMock.off).toHaveBeenCalled();
         expect(formRefMock.off).toHaveBeenCalledWith("child_changed", onReturnMock );
+    });
+
+    it('validation-error status should pass @messages in statusHandlers', async () => {
+        dbRefMock.mockReturnValue(formRefMock);
+        const statusHandlerMock = jest.fn();
+        statusTransition = ['submit', 'validation-error'];
+        runCallback();
+        expect(dbRefMock.mock.calls[0][0]).toBe(`forms/testUserId`);
+        expect(formRefMock.set)
+            .toHaveBeenCalledWith({ formData: JSON.stringify(formData), "@status": "submit"});
+        expect(formRefMock.once).toHaveBeenCalledWith('value', expect.any(Function));
+        expect(statusHandlerMock).toHaveBeenCalledTimes(2);
+        expect(statusHandlerMock).toHaveBeenCalledWith('submit',
+            {...formData, "@status": "submit"}, false);
+        expect(statusHandlerMock).toHaveBeenCalledWith('validation-error',
+            {...formData, "@status": "validation-error", "@messages": {"name": "Invalid"}}, true);
+        expect(formRefMock.off).toHaveBeenCalledWith('child_changed', expect.any(Function));
+    });
+
+    it('security-error status should pass @messages in statusHandlers', async () => {
+        dbRefMock.mockReturnValue(formRefMock);
+        const statusHandlerMock = jest.fn();
+        statusTransition = ['submit', 'security-error'];
+        runCallback();
+        expect(dbRefMock.mock.calls[0][0]).toBe(`forms/testUserId`);
+        expect(formRefMock.set)
+            .toHaveBeenCalledWith({ formData: JSON.stringify(formData), "@status": "submit"});
+        expect(formRefMock.on).toHaveBeenCalledWith('child_changed', expect.any(Function));
+        expect(statusHandlerMock).toHaveBeenCalledTimes(2);
+        expect(statusHandlerMock).toHaveBeenCalledWith('submit',
+            {...formData, "@status": "submit"}, false);
+        expect(statusHandlerMock).toHaveBeenCalledWith('security-error',
+            {...formData, "@status": "security-error", "@messages": {"name": "Invalid"}}, true);
+        expect(formRefMock.off).toHaveBeenCalledWith('child_changed', expect.any(Function));
     });
 });
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -140,6 +140,7 @@ describe('submitForm', () => {
         dbRefMock.mockReturnValue(formRefMock);
         const statusHandlerMock = jest.fn();
         statusTransition = ['submit', 'validation-error'];
+        await submitForm(formData, statusHandlerMock);
         runCallback();
         expect(dbRefMock.mock.calls[0][0]).toBe(`forms/testUserId`);
         expect(formRefMock.set)
@@ -157,6 +158,7 @@ describe('submitForm', () => {
         dbRefMock.mockReturnValue(formRefMock);
         const statusHandlerMock = jest.fn();
         statusTransition = ['submit', 'security-error'];
+        await submitForm(formData, statusHandlerMock);
         runCallback();
         expect(dbRefMock.mock.calls[0][0]).toBe(`forms/testUserId`);
         expect(formRefMock.set)

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,23 @@ export async function submitForm(
                 formRef.off('child_changed', onValueChange);
             }
 
-            statusHandler(newStatus, {...formData, "@status": newStatus}, isLastUpdate);
+            let messages;
+            if(newStatus === getStatusValue("validation-error")
+                || newStatus === getStatusValue("security-error")
+                || newStatus === getStatusValue("error")
+            ) {
+                formRef.once('value', (data) => {
+                    const currData = data.val();
+                    if(currData["@messages"]) {
+                        messages = currData["@messages"];
+                    }
+                });
+            }
+            statusHandler(
+                newStatus,
+                {...formData, "@status": newStatus, ...(messages ? {"@messages": messages} : {})},
+                isLastUpdate
+            );
             currentStatus = newStatus;
         });
 


### PR DESCRIPTION
1. Get @messages from formRef and passed it to status callback handlers
2. Added unit tests for validation and security error statuses