### PR TITLE
(Master) Resolved-Slow-Submit-Form

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -20,8 +20,7 @@ let _formData: FormData;
 async function runCallback() {
     for (let i = 0; i < statusTransition.length; i++) {
         await _callback({
-            val: jest.fn(() => (statusTransition[i])),
-            key: "@status",
+            val: jest.fn(() => ({"@status": statusTransition[i]})),
         });
     }
 }
@@ -87,13 +86,13 @@ describe('submitCancellableForm', () => {
         expect(typeof submittedForm.unsubscribe).toBe('function');
         expect(formRefMock.set).toHaveBeenCalledWith(
             {formData: JSON.stringify(formData), submittedAt: {".sv": "timestamp"}, "@status": "submit"});
-        expect(formRefMock.on).toHaveBeenCalledWith('child_changed', expect.any(Function));
+        expect(formRefMock.on).toHaveBeenCalledWith('value', expect.any(Function));
         expect(statusHandlerMock).toHaveBeenCalledTimes(2);
         expect(statusHandlerMock).toHaveBeenCalledWith('submitted',
             {...formData, submittedAt, "@status": "submitted"}, false);
         expect(statusHandlerMock).toHaveBeenCalledWith('finished',
             {...formData, submittedAt, "@status": "finished"}, true);
-        expect(formRefMock.off).toHaveBeenCalledWith('child_changed', expect.any(Function));
+        expect(formRefMock.off).toHaveBeenCalledWith('value', expect.any(Function));
     });
 
     it('cancel should return false if form has no @delay', async () => {
@@ -147,7 +146,7 @@ describe('submitCancellableForm', () => {
         await runCallback();
         await form.unsubscribe();
         expect(formRefMock.off).toHaveBeenCalled();
-        expect(formRefMock.off).toHaveBeenCalledWith("child_changed", _callback);
+        expect(formRefMock.off).toHaveBeenCalledWith("value", _callback);
     });
 
     it('validation-error status should pass @messages in statusHandlers', async () => {
@@ -167,7 +166,7 @@ describe('submitCancellableForm', () => {
             {...formData, submittedAt, "@status": "submit"}, false);
         expect(statusHandlerMock).toHaveBeenCalledWith('validation-error',
             {...formData, submittedAt, "@status": "validation-error", "@messages": {"name": "Invalid"}}, true);
-        expect(formRefMock.off).toHaveBeenCalledWith('child_changed', expect.any(Function));
+        expect(formRefMock.off).toHaveBeenCalledWith('value', expect.any(Function));
     });
 
     it('security-error status should pass @messages in statusHandlers', async () => {
@@ -182,13 +181,13 @@ describe('submitCancellableForm', () => {
         expect(formRefMock.set).toHaveBeenCalledWith({
             formData: JSON.stringify(formData), submittedAt: {".sv": "timestamp"}, "@status": "submit"
         });
-        expect(formRefMock.on).toHaveBeenCalledWith('child_changed', expect.any(Function));
+        expect(formRefMock.on).toHaveBeenCalledWith('value', expect.any(Function));
         expect(statusHandlerMock).toHaveBeenCalledTimes(2);
         expect(statusHandlerMock).toHaveBeenCalledWith('submit',
             {...formData, submittedAt, "@status": "submit"}, false);
         expect(statusHandlerMock).toHaveBeenCalledWith('security-error',
             {...formData, submittedAt, "@status": "security-error", "@messages": {"name": "Invalid"}}, true);
-        expect(formRefMock.off).toHaveBeenCalledWith('child_changed', expect.any(Function));
+        expect(formRefMock.off).toHaveBeenCalledWith('value', expect.any(Function));
     });
 });
 
@@ -252,7 +251,7 @@ describe('submitCancellableForm with timeout', () => {
             "@status": 'error',
             "@messages": "timeout waiting for last status update",
         }, true);
-        expect(formRefMock.off).toHaveBeenCalledWith('child_changed', expect.any(Function));
+        expect(formRefMock.off).toHaveBeenCalledWith('value', expect.any(Function));
     })
 
     it("should not return an error status and a message when submitCancellableForm reaches the timeout, and the status is a terminal state", async () => {
@@ -288,7 +287,7 @@ describe('submitCancellableForm with timeout', () => {
 
         await jest.advanceTimersByTime(timeout);
         expect(statusHandlerMock).toHaveBeenCalledTimes(3);
-        expect(formRefMock.off).toHaveBeenCalledWith('child_changed', expect.any(Function));
+        expect(formRefMock.off).toHaveBeenCalledWith('value', expect.any(Function));
     })
 
     it("should return a final update when submitCancellableForm reaches the timeout, and the status is in a terminal state", async () => {
@@ -324,7 +323,7 @@ describe('submitCancellableForm with timeout', () => {
             submittedAt,
             "@status": 'finished',
         }, true);
-        expect(formRefMock.off).toHaveBeenCalledWith('child_changed', expect.any(Function));
+        expect(formRefMock.off).toHaveBeenCalledWith('value', expect.any(Function));
     })
 })
 
@@ -361,13 +360,13 @@ describe('submitCancellableForm with custom status map', () => {
         expect(typeof cancelForm.cancel).toBe('function');
         expect(formRefMock.set).toHaveBeenCalledWith(
             {formData: JSON.stringify(formData), submittedAt: {".sv": "timestamp"}, "@status": "Submit"});
-        expect(formRefMock.on).toHaveBeenCalledWith('child_changed', expect.any(Function));
+        expect(formRefMock.on).toHaveBeenCalledWith('value', expect.any(Function));
         expect(statusHandlerMock).toHaveBeenCalledTimes(2);
         expect(statusHandlerMock).toHaveBeenCalledWith('Submitted',
             {...formData, submittedAt, "@status": "Submitted"}, false);
         expect(statusHandlerMock).toHaveBeenCalledWith('Finished',
             {...formData, submittedAt, "@status": "Finished"}, true);
-        expect(formRefMock.off).toHaveBeenCalledWith('child_changed', expect.any(Function));
+        expect(formRefMock.off).toHaveBeenCalledWith('value', expect.any(Function));
     });
 
     it('cancel should return false if form has no @delay', async () => {
@@ -421,7 +420,7 @@ describe('submitCancellableForm with custom status map', () => {
         runCallback();
         await form.unsubscribe();
         expect(formRefMock.off).toHaveBeenCalled();
-        expect(formRefMock.off).toHaveBeenCalledWith("child_changed", _callback);
+        expect(formRefMock.off).toHaveBeenCalledWith("value", _callback);
     });
 });
 


### PR DESCRIPTION
Problem: when form is processed immediately, listener does not receive changes and status will be handled after the time out.
Solution: Replaced  listener from child_changed to value to receive all changes from the moment the listener is attached.